### PR TITLE
Make image configurable via variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Required:
 - `anonymous_ftp_incoming_data_dir`: Directory for incoming files
 
 Optional:
+- `anonymous_ftp_banner_image`: Docker image for the FTP server
 - `anonymous_ftp_incoming_group`: Group name/id for the uploads data directory, default `root`
 - `anonymous_ftp_public_address`: Externally facing IP of the FTP server, will be guessed but it is strongly recommended that you set this
 - `anonymous_ftp_emails`: List of emails for anonymous password, default empty

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Required:
 - `anonymous_ftp_incoming_data_dir`: Directory for incoming files
 
 Optional:
-- `anonymous_ftp_banner_image`: Docker image for the FTP server
+- `anonymous_ftp_image`: Docker image for the FTP server, default `openmicroscopy/vsftpd-anonymous-upload:0.1.0`
 - `anonymous_ftp_incoming_group`: Group name/id for the uploads data directory, default `root`
 - `anonymous_ftp_public_address`: Externally facing IP of the FTP server, will be guessed but it is strongly recommended that you set this
 - `anonymous_ftp_emails`: List of emails for anonymous password, default empty

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,10 @@
 # Required: data directory for uploads. Parent directory must exist
 #anonymous_ftp_incoming_data_dir:
 
-# Group name/id for the uploads data diredctory
+# Docker image to use for the FTP server
+anonymous_ftp_image: openmicroscopy/vsftpd-anonymous-upload:0.1.0
+
+# Group name/id for the uploads data directory
 anonymous_ftp_incoming_group: root
 
 # Externally facing IP of the FTP server (advertised by the FTP server)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,7 @@
 - name: Run docker vsftpd
   become: yes
   docker_container:
-    image: openmicroscopy/vsftpd-anonymous-upload:0.1.0
+    image: {{ anonymous_ftp_image }}
     name: vsftpd
     published_ports: "{{ anonymous_ftp_published_ports }}"
     state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,7 @@
 - name: Run docker vsftpd
   become: yes
   docker_container:
-    image: {{ anonymous_ftp_image }}
+    image: "{{ anonymous_ftp_image }}"
     name: vsftpd
     published_ports: "{{ anonymous_ftp_published_ports }}"
     state: started


### PR DESCRIPTION
See https://github.com/openmicroscopy/vsftpd-anonymous-upload-docker/pull/6

This change allows to pass a different image by variable in order to test and deploy changes to the Docker images using the role.

 Proposed tag: `0.1.1` or `0.2.0`